### PR TITLE
ci: fix requirements compile script for newer uv

### DIFF
--- a/tests/requirements/compile.py
+++ b/tests/requirements/compile.py
@@ -15,8 +15,6 @@ if __name__ == "__main__":
         "compile",
         "--quiet",
         "--generate-hashes",
-        "--constraint",
-        "-",
         "requirements.in",
         *sys.argv[1:],
     ]
@@ -32,5 +30,4 @@ if __name__ == "__main__":
                 "--output-file",
                 f"py{py_version.replace('.', '')}.txt",
             ],
-            input=b"",  # No Django constraint needed
         )


### PR DESCRIPTION
## What

`tests/requirements/compile.py` passes `--constraint -` (read constraints from stdin) but always feeds it **empty** stdin — a leftover from the `django-timescaledb` sibling project where a Django version pin was piped in. Here it constrains nothing.

Newer `uv` (0.9.18) no longer maps `--constraint -` to stdin and fails with `File not found: `-``, so regenerating the locked test requirements is currently broken. Removing the flag (and the now-pointless `input=b""`) fixes it and honestly reflects that no constraints are applied.

Script-only change — the committed `pyXXX.txt` lockfiles are untouched, so no dependency-pin churn. Verified `compile.py` runs clean on uv 0.9.18 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)